### PR TITLE
Update minimum CMake version and enhance CI error handling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,5 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
+      # Check for updates to GitHub Actions every month
       interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,14 @@ jobs:
         with:
           name: Resources_Library_win64
           path: ClaRaDelay/Resources/Library/win64
+          if-no-files-found: error
 
       - name: Archive library artifacts
         uses: actions/upload-artifact@v4
         with:
           name: Resources_Library_win32
           path: ClaRaDelay/Resources/Library/win32
+          if-no-files-found: error
 
   compile-linux:
     runs-on: ubuntu-latest
@@ -91,7 +93,7 @@ jobs:
       - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '3.14.x'
+          cmake-version: '3.15.x'
 
       - name: Install gcc cross-compiler
         run: |
@@ -115,12 +117,14 @@ jobs:
         with:
           name: Resources_Library_linux64
           path: ClaRaDelay/Resources/Library/linux64/
+          if-no-files-found: error
 
       - name: Archive library artifacts
         uses: actions/upload-artifact@v4
         with:
           name: Resources_Library_linux32
           path: ClaRaDelay/Resources/Library/linux32/
+          if-no-files-found: error
 
   update-resources:
     needs: [compile-msys, compile-win, compile-linux]
@@ -137,6 +141,11 @@ jobs:
         with:
           name: Resources_Library_win64
           path: ClaRaDelay/Resources/Library/win64
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: Resources_Library_win32
+          path: ClaRaDelay/Resources/Library/win32
 
       - uses: actions/download-artifact@v4
         with:

--- a/CSource/CMakeLists.txt
+++ b/CSource/CMakeLists.txt
@@ -1,10 +1,16 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 project(ClaRaDelay C)
 
 set(PROJECT_NAME "Delay-V1")
 
 add_library(${PROJECT_NAME} STATIC "claradelay.c")
+
+if(MSVC)
+    cmake_policy(SET CMP0091 NEW)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY
+            MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif(MSVC)
 
 # Detect target platform
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ See [CSource/README.md](./CSource/README.md).
 
 ## License
 
-## Contributing
+See [CSource/LICENSE](./CSource/LICENSE).


### PR DESCRIPTION
Increased CMake's minimum required version to 3.15. 

Also, included a condition to throw an error if no files are found during artifact archival in the CI workflow, allowing earlier build problem detection. 

Updated the CI resource for win32 and reduced the frequency of GitHub Actions updates to monthly.

Link LICENSE file in README.md